### PR TITLE
Switch GA to delayed main-thread loading

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@builder.io/qwik": "^1.16.0",
         "@builder.io/qwik-city": "^1.16.0",
         "@qwik-ui/headless": "^0.6.4",
-        "@qwik.dev/partytown": "^0.11.2",
         "@types/node": "20.14.11",
         "@unocss/core": "^65.4.2",
         "@unocss/preset-icons": "^65.4.2",
@@ -284,8 +283,6 @@
 
     "@qwik-ui/headless": ["@qwik-ui/headless@0.6.4", "", { "dependencies": { "@floating-ui/core": "^1.6.2", "@floating-ui/dom": "^1.6.5", "@oddbird/popover-polyfill": "0.4.3", "body-scroll-lock-upgrade": "^1.1.0", "focus-trap": "7.5.4" }, "peerDependencies": { "@builder.io/qwik": ">=1.3.1" } }, "sha512-ZHKB3UpJGTzOEfy1c8VTppndQb6dZfIXael9DaNxpaSUWI/Zd88lV4fEBNZ1x//FezvbRybHLwJtVpQ8xmvz3g=="],
 
-    "@qwik.dev/partytown": ["@qwik.dev/partytown@0.11.2", "", { "dependencies": { "dotenv": "^16.4.7" }, "bin": { "partytown": "bin/partytown.cjs" } }, "sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw=="],
-
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-beta.38", "", { "os": "android", "cpu": "arm64" }, "sha512-AE3HFQrjWCKLFZD1Vpiy+qsqTRwwoil1oM5WsKPSmfQ5fif/A+ZtOZetF32erZdsR7qyvns6qHEteEsF6g6rsQ=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-beta.38", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RaoWOKc0rrFsVmKOjQpebMY6c6/I7GR1FBc25v7L/R7NlM0166mUotwGEv7vxu7ruXH4SJcFeVrfADFUUXUmmQ=="],
@@ -517,8 +514,6 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
-
-    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@builder.io/qwik": "^1.16.0",
     "@builder.io/qwik-city": "^1.16.0",
     "@qwik-ui/headless": "^0.6.4",
-    "@qwik.dev/partytown": "^0.11.2",
     "@types/node": "20.14.11",
     "@unocss/core": "^65.4.2",
     "@unocss/preset-icons": "^65.4.2",

--- a/src/components/partytown/partytown.tsx
+++ b/src/components/partytown/partytown.tsx
@@ -1,8 +1,0 @@
-import type { PartytownConfig } from '@qwik.dev/partytown/integration'
-import { partytownSnippet } from '@qwik.dev/partytown/integration'
-
-export interface PartytownProps extends PartytownConfig {}
-
-export const QwikPartytown = (props: PartytownProps) => {
-  return <script dangerouslySetInnerHTML={partytownSnippet(props)} />
-}

--- a/src/components/router-head/router-head.tsx
+++ b/src/components/router-head/router-head.tsx
@@ -20,18 +20,35 @@ export const RouterHead = component$(() => {
       <meta name="twitter:creator" content="@nakasyou0" />
 
       <script
-        type="text/partytown"
-        async
-        src="https://www.googletagmanager.com/gtag/js?id=G-XCPC66GQ5T"
-      ></script>
-      <script
-        type="text/partytown"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: this is a static script
         dangerouslySetInnerHTML={`
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-XCPC66GQ5T');
+      (() => {
+        const GA_ID = 'G-XCPC66GQ5T';
+        if (navigator.doNotTrack === '1') return;
+        if (window.__gaLoaded) return;
+
+        const init = () => {
+          if (window.__gaLoaded) return;
+          window.__gaLoaded = true;
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = function gtag(){dataLayer.push(arguments);};
+
+          const script = document.createElement('script');
+          script.async = true;
+          script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
+          script.onload = () => {
+            window.gtag('js', new Date());
+            window.gtag('config', GA_ID);
+          };
+          document.head.appendChild(script);
+        };
+
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(init, { timeout: 2500 });
+        } else {
+          setTimeout(init, 2000);
+        }
+      })();
     `}
       />
 

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -4,7 +4,6 @@ import {
   RouterOutlet,
   ServiceWorkerRegister,
 } from '@builder.io/qwik-city'
-import { QwikPartytown } from './components/partytown/partytown'
 import { RouterHead } from './components/router-head/router-head'
 
 import 'uno.css'
@@ -28,7 +27,6 @@ export default component$(() => {
             href={`${import.meta.env.BASE_URL}manifest.json`}
           />
         )}
-        <QwikPartytown forward={['dataLayer.push']} />
         <RouterHead />
       </head>
       <body lang="en">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,6 @@
 import { qwikVite } from '@builder.io/qwik/optimizer'
 import { qwikCity } from '@builder.io/qwik-city/vite'
-import { partytownVite } from '@qwik.dev/partytown/utils'
 import uno from '@unocss/vite'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 /**
  * This is the base config for vite.
  * When building, the adapter config is used which loads this file and extends it.
@@ -20,20 +17,12 @@ const { dependencies = {}, devDependencies = {} } = pkg as unknown as {
 }
 errorOnDuplicatesPkgDeps(devDependencies, dependencies)
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
 /**
  * Note that Vite normally starts from `index.html` but the qwikCity plugin makes start at `src/entry.ssr.tsx` instead.
  */
 export default defineConfig((): UserConfig => {
   return {
-    plugins: [
-      uno(),
-      qwikCity(),
-      qwikVite(),
-      tsconfigPaths(),
-      partytownVite({ dest: join(__dirname, 'dist', '~partytown') }),
-    ],
+    plugins: [uno(), qwikCity(), qwikVite(), tsconfigPaths()],
     // This tells Vite which dependencies to pre-build in dev mode.
     optimizeDeps: {
       // Put problematic deps that break bundling here, mostly those with binaries.


### PR DESCRIPTION
## Summary
- remove Partytown integration and dependency
- switch GA to delayed main-thread loading (`requestIdleCallback` with `setTimeout` fallback)
- keep DNT guard (`navigator.doNotTrack === '1'`)
- keep duplicate init guard (`window.__gaLoaded`)

## Why
- remove Lighthouse Best Practices deprecation warnings caused by Partytown sandbox
- keep analytics with lower impact via delayed load strategy
