### PR TITLE
Add m1ntooo.com to mutual links

### DIFF
--- a/src/data/mutual-links.ts
+++ b/src/data/mutual-links.ts
@@ -60,4 +60,10 @@ export const mutualLinks = [
     addedAt: '2025-06-22',
     url: 'https://ynai20.vercel.app',
   },
+  {
+    name: 'm1ntooo.com',
+    author: 'みんとさん',
+    addedAt: '2026-04-01',
+    url: 'https://m1ntooo.com',
+  },
 ]


### PR DESCRIPTION
### Motivation
- Add a mutual link entry for `m1ntooo.com` per issue #7, recording author `みんとさん` and setting `addedAt` to `2026-04-01` (issue date: "今日").

### Description
- Update `src/data/mutual-links.ts` to append a new object for `m1ntooo.com` with `name`, `author`, `addedAt`, and `url` fields.

### Testing
- `npm run build.types` was executed and failed in this environment because dependencies are not installed, producing unrelated type resolution errors, so no additional automated tests specific to this trivial data change were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccc95bc18083329f8940636adf6fad)